### PR TITLE
Fix volume names in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       MYSQL_DATABASE: wordpress
       MYSQL_USER: wordpress
       MYSQL_PASSWORD: wordpress
-    
+
   wordpress:
     depends_on:
       - db
@@ -26,6 +26,7 @@ services:
       WORDPRESS_DB_USER: wordpress
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_NAME: wordpress
+
 volumes:
-  db_data: {}
-  wordpress_data: {}
+  database:
+  src:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This is a very simple change. The docker-compose file references the wrong names for volumes associated with the db and wordpress services. 

I replaced this: 

```
volumes:
  db_data: {}
  wordpress_data: {}
```

with this: 

```
volumes:
  database: 
  src: 
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #1 

## How to test
<!-- Provide steps to test this PR -->
Before this change, if you attempted to click the Gitpod button on the main branch of this repo, you would experience the error described in the issue. 

With this change, you should simply be able to click the Gitpod button for this branch, and successfully launch a Gitpod environment. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```
Volume names in docker-compose.yml file have been updated.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No documentation updates are required. 
